### PR TITLE
Fix TypeError from trying to call a boolean

### DIFF
--- a/django_adminlte/templatetags/adminlte_helpers.py
+++ b/django_adminlte/templatetags/adminlte_helpers.py
@@ -17,7 +17,7 @@ def avatar_url(context, size=None, user=None):
     # TODO: Make behaviour configurable
     user = context['request'].user if user is None else user
     return 'https://www.gravatar.com/avatar/{hash}?s={size}&d=mm'.format(
-        hash=md5(user.email.encode('utf-8')).hexdigest() if user.is_authenticated() else '',
+        hash=md5(user.email.encode('utf-8')).hexdigest() if user.is_authenticated else '',
         size=size or '',
     )
 


### PR DESCRIPTION
user.is_authenticated is a boolean value in Django 2.0, this causes a TypeError when trying to load the page with adminlte2 templates.

Example end of stack trace for loading the admin site:
```
File "/usr/lib/python3.6/site-packages/django_adminlte/templatetags/adminlte_helpers.py" in avatar_url
  20.         hash=md5(user.email.encode('utf-8')).hexdigest() if user.is_authenticated() else '',

Exception Type: TypeError at /admin/
Exception Value: 'bool' object is not callable
```