### PR TITLE
Fixing django-polymorphic admin integration raises KeyError 'available_apps'

### DIFF
--- a/django_adminlte_theme/templatetags/admin_menu.py
+++ b/django_adminlte_theme/templatetags/admin_menu.py
@@ -99,6 +99,9 @@ class _Menu:
         return r
 
     def admin_apps(self, context, r):
+        if 'available_apps' not in context:
+            return r
+
         request = context['request']
         for app in context['available_apps']:
             r += '<li class="treeview"><a href="#"><i class="fa fa-circle"></i> <span>%s</span><span class="pull-right-container"><i class="fa fa-angle-left pull-right"></i></span></a><ul class="treeview-menu">\n' % (


### PR DESCRIPTION
When adding model that inherits from [django-polymorphic](https://django-polymorphic.readthedocs.io/en/stable/index.html) `PolymorphicModel` in admin, the following error is thrown:
```
  File "/home/ubuntu/managedprojects/env/lib/python3.8/site-packages/django_adminlte_theme/templatetags/admin_menu.py", line 159, in menu_tag
    return Menu.admin_apps(context, Menu.render(context))
  File "/home/ubuntu/managedprojects/env/lib/python3.8/site-packages/django_adminlte_theme/templatetags/admin_menu.py", line 103, in admin_apps
    for app in context['available_apps']:
  File "/home/ubuntu/managedprojects/env/lib/python3.8/site-packages/django/template/context.py", line 83, in __getitem__
    raise KeyError(key)
KeyError: 'available_apps'
```